### PR TITLE
Fix for when a repeatable field name is null

### DIFF
--- a/lib/Indexer.php
+++ b/lib/Indexer.php
@@ -312,16 +312,18 @@ class Indexer extends Base {
         $index = [];
         $index_num = 0;
         $prefixes = $this->getOptions()['prefixes'];
-        foreach ($page->get($field->name) as $child) {
-            if ($child->status >= \ProcessWire\Page::statusHidden) continue;
-            $args = [
-                'id_prefix' => str_replace('{field.name}', $field->name, $prefixes['id'] ?? ''),
-                'name_prefix' => str_replace('{field.name}', $field->name, $prefixes['name'] ?? ''),
-            ];
-            // Note: union operator is slightly faster than array_merge() and makes sense here since we're working with
-            // associative arrays only.
-            $index += $this->getPageIndex($child, $indexed_fields, $prefix . $field->name . '.' . $index_num . '.', $args);
-            ++$index_num;
+        if (null !== $page->get($field->name)) {
+            foreach ($page->get($field->name) as $child) {
+                if ($child->status >= \ProcessWire\Page::statusHidden) continue;
+                $args = [
+                    'id_prefix' => str_replace('{field.name}', $field->name, $prefixes['id'] ?? ''),
+                    'name_prefix' => str_replace('{field.name}', $field->name, $prefixes['name'] ?? ''),
+                ];
+                // Note: union operator is slightly faster than array_merge() and makes sense here since we're working with
+                // associative arrays only.
+                $index += $this->getPageIndex($child, $indexed_fields, $prefix . $field->name . '.' . $index_num . '.', $args);
+                ++$index_num;
+            }
         }
         return $index;
     }


### PR DESCRIPTION
I've customized a RepeaterMatrix field in certain ProcessWire templates to remove certain fields when accessed from those templates. I believe this to be the problem. Rather than checking which fields are available and only looping through them, this simply runs a check to verify that the field name exists prior to entering the `foreach` loop in the Indexer's ___getRepeatableIndexValue() method.

Although further testing is recommended, this particular addition should not cause any problems, and only prevents an edge case error.