### PR TITLE
Fix lib/Processor.php's processIndex() thrown WARNING

### DIFF
--- a/lib/Processor.php
+++ b/lib/Processor.php
@@ -35,6 +35,9 @@ class Processor extends Base {
             $processed_index = array_filter($index, function($index_key) {
                 return strpos($index_key, Indexer::META_PREFIX) !== 0;
             }, ARRAY_FILTER_USE_KEY);
+            // Flatten any multidimensional arrays to a single dimension, then convert to string for indexing
+            $processed_index = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($processed_index));
+            $processed_index = iterator_to_array($processed_index, false);
             $processed_index = implode(' ... ', $processed_index);
             $processed_index = str_replace('<', ' <', $processed_index);
             if (!$args['withTags']) {


### PR DESCRIPTION
Fixes an issue with implode() and a WARNING of array to string conversion. Code adjustment should be compatible with PHP >= v5.1.0.

See https://processwire.com/talk/topic/21941-searchengine/page/11/#comment-233780 for more information.