### PR TITLE
fix: Fix type safety in SearchEngine Indexer's field value handling

### DIFF
--- a/lib/Indexer.php
+++ b/lib/Indexer.php
@@ -408,16 +408,29 @@ class Indexer extends Base {
      *
      * @param \ProcessWire\WireData $object
      * @param string $field_name
-     * @return mixed
+     * @return string|null
      */
-    protected function getFormattedFieldValue(\ProcessWire\WireData $object, string $field_name) {
+    protected function getFormattedFieldValue(\ProcessWire\WireData $object, string $field_name): ?string {
+        $val = null;
+
         if ($object instanceof \ProcessWire\Page) {
-            return $object->getFormatted($field_name);
+            $val = $object->getFormatted($field_name);
+        } elseif ($object instanceof \ProcessWire\Field && method_exists($object, 'getFieldValue')) {
+            $val = $object->getFieldValue($field_name, true);
+        } else {
+            $val = $object->get($field_name);
         }
-        if ($object instanceof \ProcessWire\Field && method_exists($object, 'getFieldValue')) {
-            return $object->getFieldValue($field_name, true);
+
+        // Handle non-string values
+        if (is_array($val)) {
+            return implode(' ', $val);
+        } elseif (is_object($val) && method_exists($val, '__toString')) {
+            return (string) $val;
+        } elseif (is_object($val)) {
+            return '';
         }
-        return $object->get($field_name);
+
+        return $val === null ? null : (string) $val;
     }
 
     /**


### PR DESCRIPTION
## Problem

In some very rare edge cases, value of empty PageTitleLanguage fields inside repeaters were returned as array and caused a TypeError. 
![image](https://github.com/user-attachments/assets/aa76a455-9f80-4f36-b6dd-dd2815f1fffa)


The `___getIndexValue` method passes the return value of `getFormattedFieldValue` directly to the `IndexValue` constructor in (old) L 295 without type checking. Since `getFormattedFieldValue` returns `mixed` type and `IndexValue` constructor requires `?string`, this can cause `TypeError` exceptions when non-string values (arrays, objects) are returned.

## Solution

Modified the `getFormattedFieldValue` method to:
- Change return type from `mixed` to `?string`
- Fix control flow with proper conditional structure
- Handle type conversion for different value types:
  - Arrays are converted to strings using `implode()`
  - Objects with `__toString()` method are properly cast to strings
  - Other objects are converted to empty strings
  - Non-null scalar values are cast to strings
  - Null values are preserved as null

This ensures the method always returns values compatible with the `IndexValue` constructor, preventing potential runtime errors while maintaining expected behavior.
